### PR TITLE
chore(deps): update pocket to latest

### DIFF
--- a/.pocket/config.go
+++ b/.pocket/config.go
@@ -18,8 +18,4 @@ var Config = &pk.Config{
 			),
 		),
 	),
-
-	Plan: &pk.PlanConfig{
-		Shims: pk.DefaultShimConfig(),
-	},
 }

--- a/.pocket/config.go
+++ b/.pocket/config.go
@@ -20,8 +20,6 @@ var Config = &pk.Config{
 	),
 
 	Plan: &pk.PlanConfig{
-		Shims: &pk.ShimConfig{
-			Posix: true, // pok (POSIX shell script)
-		},
+		Shims: pk.DefaultShimConfig(),
 	},
 }

--- a/.pocket/go.mod
+++ b/.pocket/go.mod
@@ -2,7 +2,7 @@ module pocket
 
 go 1.26.1
 
-require github.com/fredrikaverpil/pocket v0.0.0-20260315084410-bafaf8ac24a7
+require github.com/fredrikaverpil/pocket v0.0.0-20260315110739-a2539deb8a86
 
 require (
 	golang.org/x/sync v0.19.0 // indirect

--- a/.pocket/go.mod
+++ b/.pocket/go.mod
@@ -2,7 +2,7 @@ module pocket
 
 go 1.26.1
 
-require github.com/fredrikaverpil/pocket v0.0.0-20260315080520-e523b07f7cbe
+require github.com/fredrikaverpil/pocket v0.0.0-20260315084410-bafaf8ac24a7
 
 require (
 	golang.org/x/sync v0.19.0 // indirect

--- a/.pocket/go.sum
+++ b/.pocket/go.sum
@@ -1,5 +1,5 @@
-github.com/fredrikaverpil/pocket v0.0.0-20260315084410-bafaf8ac24a7 h1:gj988YZWD+PJq/JLfmmakm5iIvRjOX7UMYw7qLnUOaI=
-github.com/fredrikaverpil/pocket v0.0.0-20260315084410-bafaf8ac24a7/go.mod h1:/Yrpyu8n8psheBv/3pVgIoz+KVsWwSy0ueU7xzOKf4w=
+github.com/fredrikaverpil/pocket v0.0.0-20260315110739-a2539deb8a86 h1:jCEAUeR9K1pwwL9xzzU63joIxUVIGRtlVjAQw9A0xQQ=
+github.com/fredrikaverpil/pocket v0.0.0-20260315110739-a2539deb8a86/go.mod h1:/Yrpyu8n8psheBv/3pVgIoz+KVsWwSy0ueU7xzOKf4w=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=

--- a/.pocket/go.sum
+++ b/.pocket/go.sum
@@ -1,8 +1,12 @@
-github.com/fredrikaverpil/pocket v0.0.0-20260315080520-e523b07f7cbe h1:ENbHk7W2jAG/L+QoGp2CgtrY0e+EfvcdqIw8z0ph5us=
-github.com/fredrikaverpil/pocket v0.0.0-20260315080520-e523b07f7cbe/go.mod h1:/Yrpyu8n8psheBv/3pVgIoz+KVsWwSy0ueU7xzOKf4w=
+github.com/fredrikaverpil/pocket v0.0.0-20260315084410-bafaf8ac24a7 h1:gj988YZWD+PJq/JLfmmakm5iIvRjOX7UMYw7qLnUOaI=
+github.com/fredrikaverpil/pocket v0.0.0-20260315084410-bafaf8ac24a7/go.mod h1:/Yrpyu8n8psheBv/3pVgIoz+KVsWwSy0ueU7xzOKf4w=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=
 golang.org/x/term v0.40.0/go.mod h1:w2P8uVp06p2iyKKuvXIm7N/y0UCRt3UfJTfZ7oOpglM=
+gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
+gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=


### PR DESCRIPTION
## Why
Update Pocket dependency to the latest version and use idiomatic helper for shim config.

## What
- Update `.pocket/go.mod` and `.pocket/go.sum` to use Pocket at commit `bafaf8ac24a71e0aac316db8ce2ecf3d6778f307`
- Replace `&pk.ShimConfig{Posix: true}` with `pk.DefaultShimConfig()` in `config.go`